### PR TITLE
New Feature: add completed status color + tinted completed rows

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,13 +1,20 @@
 import React, { useMemo, useState } from 'react';
-import { View, Text, FlatList, Pressable, StyleSheet } from 'react-native';
+import { View, Text, FlatList, Pressable, Modal, StyleSheet } from 'react-native';
 import { Link } from 'expo-router';
 import TaskItem from '../components/TaskItem';
 import SearchBar from '../components/SearchBar';
 import { useTasks } from '../lib/store';
 
+// a set of light color options
+const SWATCHES = ['#E6F4EA', '#E0F2FE', '#EDE9FE', '#FEF3C7', '#E5E7EB'];
+
 export default function HomeScreen() {
   const { state, dispatch } = useTasks();
   const [query, setQuery] = useState('');
+  const [open, setOpen] = useState(false); // controls of the modal
+
+ // get from global settings
+  const completeColor = state.settings.completeColor;
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -16,8 +23,15 @@ export default function HomeScreen() {
   }, [state.tasks, query]);
 
   return (
-    <View style={styles.container}>
-      <SearchBar value={query} onChange={setQuery} />
+    <View style={{ flex : 1 }}>
+        <View style ={styles.topBar}>
+          <SearchBar value={query} onChange={setQuery} />
+          {/* Color Picker */}
+          <Pressable onPress={() => setOpen(true)} style={styles.colorBtn}>
+            <Text style={styles.colorBtnText}>Status Color</Text>
+          </Pressable>
+        </View>
+
       <FlatList
         contentContainerStyle={{ padding: 16 }}
         data={filtered}
@@ -26,38 +40,77 @@ export default function HomeScreen() {
         renderItem={({ item }) => (
           <TaskItem
             task={item}
+            completeColor={completeColor} // pass color
             onToggle={(id) => dispatch({ type: 'toggle', payload: { id } })}
             onDelete={(id) => dispatch({ type: 'delete', payload: { id } })}
           />
         )}
       />
-      <Link href="/add" asChild>
-        <Pressable style={styles.fab}>
-          <Text style={styles.fabText}>＋</Text>
-        </Pressable>
-      </Link>
+
+      {/* Color Picker Modal */}
+      <Modal visible={open} transparent animationType="fade" onRequestClose={() => setOpen(false)}>
+        <View style={styles.overlay}>
+          <View style={styles.sheet}>
+            <Text style={styles.sheetTitle}>Choose Complete Color</Text>
+            <View style={styles.swatchRow}>
+                {SWATCHES.map(color => (
+                  <Pressable
+                    key={color}
+                    onPress={() => {
+                        dispatch({ type: 'setCompleteColor', payload: { color } }); // save to global settings
+                        setOpen(false);
+                    }}
+                    style={[styles.swatch, { backgroundColor: color }]}
+                    />
+                ))}
+            </View>
+            <Pressable onPress={() => setOpen(false)} style={styles.cancelBtn}>
+              <Text style={styles.cancelText}>Cancel</Text>
+            </Pressable>
+          </View>
+        </View>
+      </Modal>
+
+      <View pointerEvents="box-none" style={styles.fabWrap}>
+        <Link href="/add" asChild>
+            <Pressable style={styles.fab}>
+              <Text style={styles.fabText}>＋</Text>
+            </Pressable>
+        </Link>
+      </View>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, backgroundColor: '#f5f5f5' },
-  empty: { textAlign: 'center', color: '#666', marginTop: 40 },
-  fab: {
-    position: 'absolute',
-    right: 24,
-    bottom: 24,
-    width: 56,
-    height: 56,
-    borderRadius: 28,
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: '#2563eb',
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 1 },
-    shadowOpacity: 0.2,
-    shadowRadius: 1.41,
-    elevation: 2
+  topBar: {
+    paddingHorizontal: 16, paddingTop: 8, gap: 8,
+    backgroundColor: '#fff', borderBottomWidth: 1, borderColor: '#E5E7EB',
   },
-  fabText: { color: '#fff', fontSize: 28, fontWeight: '600', lineHeight: 28 }
+  colorBtn: {
+    alignSelf: 'flex-start', backgroundColor: '#2563EB',
+    paddingHorizontal: 12, paddingVertical: 8, borderRadius: 10,
+  },
+  colorBtnText: { color: '#fff', fontWeight: '700' },
+
+  // Modal style
+  overlay: { flex: 1, backgroundColor: 'rgba(0,0,0,0.35)', alignItems: 'center', justifyContent: 'center' },
+  sheet: { width: '85%', backgroundColor: '#fff', borderRadius: 16, padding: 16, gap: 12, borderWidth: 1, borderColor: '#E5E7EB' },
+  sheetTitle: { fontSize: 16, fontWeight: '700' },
+  swatchRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 12 },
+  swatch: { width: 36, height: 36, borderRadius: 18, borderWidth: 1, borderColor: '#D1D5DB' },
+  cancelBtn: { alignSelf: 'flex-end', paddingHorizontal: 12, paddingVertical: 8 },
+  cancelText: { color: '#2563EB', fontWeight: '700' },
+
+  // fabWrap to position the button floats over content
+  fabWrap: { position: 'absolute', right: 24, bottom: 24, zIndex: 100, elevation: 8 },
+  fab: {
+    width: 56, height: 56, borderRadius: 28,
+    alignItems: 'center', justifyContent: 'center',
+    backgroundColor: '#2563EB',
+    shadowColor: '#000', shadowOpacity: 0.2, shadowRadius: 6,
+    shadowOffset: { width: 0, height: 3 },
+    elevation: 6,
+  },
+  fabText: { color: '#fff', fontSize: 28, fontWeight: '800', lineHeight: 30 },
 });

--- a/components/TaskItem.tsx
+++ b/components/TaskItem.tsx
@@ -7,11 +7,17 @@ interface Props {
   task: Task;
   onToggle: (id: string) => void;
   onDelete: (id: string) => void;
+  completeColor: string; // color for completed tasks
 }
 
-export default function TaskItem({ task, onToggle, onDelete }: Props) {
+export default function TaskItem({ task, onToggle, onDelete, completeColor }: Props) {
+  // Dynamic style for completed tasks
+  const containerStyle = [
+    styles.container,
+    task.status == 'completed' && { backgroundColor: completeColor }
+  ];
   return (
-    <View style={styles.container}>
+    <View style={containerStyle}>
       <Pressable onPress={() => onToggle(task.id)} style={styles.status}>
         <Text style={styles.statusText}>{task.status === 'completed' ? '✓' : '○'}</Text>
       </Pressable>
@@ -44,7 +50,7 @@ const styles = StyleSheet.create({
     padding: 12,
     borderRadius: 12,
     borderWidth: 1,
-    borderColor: '#E6E6E6',
+    borderColor: '#E5E7EB',
     marginBottom: 10,
     backgroundColor: '#fff',
     gap: 12


### PR DESCRIPTION
### Summary
- Add settings.completeColor (default #E6F4EA, light green)
- New setCompleteColor action in reducer
- “Status Color” button + modal swatches on HomePage
- TaskItem tints background when status === 'completed'
- Ensure reducer branches keep ...state (preserve settings)

### Test
- Pick a color → toggle a task → row tint updates
- Add/edit/delete → no UI regression

### Scope
- UI/State only; no API changes.